### PR TITLE
Fix external analytics URLs

### DIFF
--- a/22-rue-Muller/index.html
+++ b/22-rue-Muller/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Archive-1/index.html
+++ b/Archive-1/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Artefact/index.html
+++ b/Artefact/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Besixdouze/index.html
+++ b/Besixdouze/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Bollyhouse-Jalousy/index.html
+++ b/Bollyhouse-Jalousy/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/CH2-n/index.html
+++ b/CH2-n/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/CHC/index.html
+++ b/CHC/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Dakhla/index.html
+++ b/Dakhla/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Deleuze-Chromatique/index.html
+++ b/Deleuze-Chromatique/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Drift-k/index.html
+++ b/Drift-k/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Drift-pp/index.html
+++ b/Drift-pp/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Echoplasma/index.html
+++ b/Echoplasma/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Franck/index.html
+++ b/Franck/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Fugologie/index.html
+++ b/Fugologie/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Interstice/index.html
+++ b/Interstice/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/L-Adhan-de-Marrakech/index.html
+++ b/L-Adhan-de-Marrakech/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/L-echelle/index.html
+++ b/L-echelle/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/L-etreinte/index.html
+++ b/L-etreinte/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/La-Dame-de-Marrakech/index.html
+++ b/La-Dame-de-Marrakech/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/La-Porte/index.html
+++ b/La-Porte/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Le-Bateau-de-Thesee/index.html
+++ b/Le-Bateau-de-Thesee/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Le-Detail-de-L-histoire/index.html
+++ b/Le-Detail-de-L-histoire/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Le-Fumeur-du-Champs-de-Mars/index.html
+++ b/Le-Fumeur-du-Champs-de-Mars/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Le-Labyrinthe-de-The-se-e/index.html
+++ b/Le-Labyrinthe-de-The-se-e/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Les-Poetes-Intrigants/index.html
+++ b/Les-Poetes-Intrigants/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/M-beach/index.html
+++ b/M-beach/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Mbote-Mingi/index.html
+++ b/Mbote-Mingi/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Messe-Zombie/index.html
+++ b/Messe-Zombie/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Micro-colloque/index.html
+++ b/Micro-colloque/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Moving-Forest-La-Table-des-Strategies/index.html
+++ b/Moving-Forest-La-Table-des-Strategies/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Nox-Rufus/index.html
+++ b/Nox-Rufus/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Old-North-Bridge/index.html
+++ b/Old-North-Bridge/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Ondulation/index.html
+++ b/Ondulation/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Piu/index.html
+++ b/Piu/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Pnose/index.html
+++ b/Pnose/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Sentimental-Market/index.html
+++ b/Sentimental-Market/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Symphonie/index.html
+++ b/Symphonie/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Tchala/index.html
+++ b/Tchala/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Thesee/index.html
+++ b/Thesee/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Tiraj-Lavi/index.html
+++ b/Tiraj-Lavi/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/Vestige/index.html
+++ b/Vestige/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/X-Intrigue/index.html
+++ b/X-Intrigue/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/X-Selon-X/index.html
+++ b/X-Selon-X/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/activites/index.html
+++ b/activites/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/atelier/index.html
+++ b/atelier/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/bio/index.html
+++ b/bio/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/collectif/index.html
+++ b/collectif/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/filter/installation/index.html
+++ b/filter/installation/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/filter/performance/index.html
+++ b/filter/performance/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/filter/photographie/index.html
+++ b/filter/photographie/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/filter/recherche/index.html
+++ b/filter/recherche/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/filter/video/index.html
+++ b/filter/video/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/intention/index.html
+++ b/intention/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/laboratoire-fugologique/index.html
+++ b/laboratoire-fugologique/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">

--- a/liens/index.html
+++ b/liens/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="../../www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="../../www.google-analytics.com/analytics.js"></script>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js/index%EF%B9%96id=G-HKBRS8R4T2&amp;cx=c&amp;_slc=1.js"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="verify-v1" content="STDtWvgGjOy77mPN8tNAAfDaBqDkqWU7AHfu7opE3NQ=">
 	<meta name="description" content="">


### PR DESCRIPTION
## Summary
- fix relative Google script URLs by using HTTPS forms

## Testing
- `grep -Rl '../[.]*www.googletagmanager.com' --include=*.html`
- `grep -Rl '../[.]*www.google-analytics.com' --include=*.html`

------
https://chatgpt.com/codex/tasks/task_e_687d0a233f708323913ff4973c1afe0e